### PR TITLE
Change instructions to use the `ncss` compiler

### DIFF
--- a/src/components/TutorialPreReqs.tsx
+++ b/src/components/TutorialPreReqs.tsx
@@ -78,7 +78,7 @@ export default function TutorialPreReqs({ mode }: Props) {
           code.
         </li>
         <li>
-          <strong>Neon smart contract compiler</strong> &mdash;{" "}
+          <strong>Neo C# smart contract compiler</strong> &mdash;{" "}
           <a href="https://github.com/neo-project/neo-devpack-dotnet">
             https://github.com/neo-project/neo-devpack-dotnet
           </a>
@@ -102,7 +102,7 @@ export default function TutorialPreReqs({ mode }: Props) {
       >
         <p>
           For a step-by-step walkthrough showing how to install the C# VS Code
-          extension and the Neon compiler, see:{" "}
+          extension and the Neo C# compiler, see:{" "}
           <a href="./quickstart4.html">Quick Start video 4</a>.
         </p>
         <p>

--- a/src/data/quickStarts.tsx
+++ b/src/data/quickStarts.tsx
@@ -71,12 +71,15 @@ const quickStarts: QuickStart[] = [
       </p>,
       <p>Commands used in this video:</p>,
       <p style={{ marginLeft: 30 }}>
-        <em>Installing the Neon compiler:</em>
+        <em>Installing the Neo C# compiler:</em>
         <br />
-        <code>$ dotnet tool install -g neo.neon --version 3.0.0-rc1</code>
+        <code>
+          $ dotnet tool install -g neo.compiler.csharp --version 3.0.0-rc2
+        </code>
         <br />
-        (The --version parameter will no longer be required after the final N3
-        release.)
+        (Please note that the tool name has changed since the video was
+        recorded. ALso note that the --version parameter will no longer be
+        required after the final N3 release.)
       </p>,
     ],
   },

--- a/src/data/tutorials/nep17.tsx
+++ b/src/data/tutorials/nep17.tsx
@@ -660,7 +660,7 @@ namespace XyzToken
             we’ll call the event <code>OnTransfer</code>—as this is a common
             convention for events in C# code—and we’ll use a{" "}
             <code>DisplayName</code>
-            attribute so that the Neon compiler knows that this is the{" "}
+            attribute so that the Neo C# compiler knows that this is the{" "}
             <code>Transfer</code>
             event:
           </p>


### PR DESCRIPTION
Note: This should not be deployed to GitHub Pages until after the changes in https://github.com/ngdenterprise/neo3-visual-tracker/pull/79 have been deployed to the VS Code Marketplace.

Fixes #10 